### PR TITLE
Add capability to use multiple stubs

### DIFF
--- a/lib/gcr.rb
+++ b/lib/gcr.rb
@@ -47,6 +47,7 @@ module GCR
   def stub=(stub)
     raise RunningError, "cannot configure GCR within #with_cassette block" if @running
     @stub = stub
+    (@stubs ||= Set.new) << stub
   end
 
   # The stub that is being mocked.
@@ -54,6 +55,11 @@ module GCR
   # Returns a A GRPC::ClientStub instance. Raises ConfigError if not configured.
   def stub
     @stub || (raise ConfigError, "no stub configured")
+  end
+
+  def stubs
+    @stubs || (raise ConfigError, "no stubs configured")
+    @stubs.to_a
   end
 
   def insert(name)

--- a/lib/gcr/cassette.rb
+++ b/lib/gcr/cassette.rb
@@ -97,7 +97,6 @@ class GCR::Cassette
     GCR.stubs.each do |klass|
       klass.class_eval do
         alias_method :request_response, :orig_request_response
-        undef :orig_request_response
       end if klass.respond_to?(:orig_request_response)
     end
     save
@@ -125,7 +124,6 @@ class GCR::Cassette
     GCR.stubs.each do |klass|
       klass.class_eval do
         alias_method :request_response, :orig_request_response
-        undef :orig_request_response
       end if klass.respond_to?(:orig_request_response)
     end
   end


### PR DESCRIPTION
# Overview
Add ability to use multiple stubs.

## Details
* previous implementation only considered 1 stub, but there are times
  when multiple stubs are used within 1 test/spec
* GCR should be told about stubs *before* `start_playing` or
  `start_recording` (i.e., before `with_cassette`) so that requests can be intercepted and recorded
  properly
* ~~improve cleanup by undef'ing `#orig_request_response`, which also
  asserts that the method exists (was intercepted properly)~~
  
  ## Limitations
 * no way to easily remove/reset stubs
 * no additional specs added