### PR TITLE
Fix: intercept #request_response on class, not instance

### DIFF
--- a/lib/gcr/cassette.rb
+++ b/lib/gcr/cassette.rb
@@ -77,8 +77,8 @@ class GCR::Cassette
   end
 
   def start_recording
-    GCR.stubs.each do |klass|
-      klass.class_eval do
+    GCR.stubs.each do |instance|
+      instance.class.class_eval do
         alias_method :orig_request_response, :request_response
 
         def request_response(*args)
@@ -89,15 +89,15 @@ class GCR::Cassette
             end
           end
         end
-      end unless klass.respond_to?(:orig_request_response)
+      end unless instance.class.respond_to?(:orig_request_response)
     end
   end
 
   def stop_recording
-    GCR.stubs.each do |klass|
-      klass.class_eval do
+    GCR.stubs.each do |instance|
+      instance.class.class_eval do
         alias_method :request_response, :orig_request_response
-      end if klass.respond_to?(:orig_request_response)
+      end if instance.class.respond_to?(:orig_request_response)
     end
     save
   end
@@ -105,8 +105,8 @@ class GCR::Cassette
   def start_playing
     load
 
-    GCR.stubs.each do |klass|
-      klass.class_eval do
+    GCR.stubs.each do |instance|
+      instance.class.class_eval do
         alias_method :orig_request_response, :request_response
 
         def request_response(*args)
@@ -116,15 +116,15 @@ class GCR::Cassette
           end
           raise GCR::NoRecording
         end
-      end if !klass.respond_to?(:orig_request_response)
+      end if !instance.class.respond_to?(:orig_request_response)
     end
   end
 
   def stop_playing
-    GCR.stubs.each do |klass|
-      klass.class_eval do
+    GCR.stubs.each do |instance|
+      instance.class.class_eval do
         alias_method :request_response, :orig_request_response
-      end if klass.respond_to?(:orig_request_response)
+      end if instance.class.respond_to?(:orig_request_response)
     end
   end
 


### PR DESCRIPTION
# Overview
Fix to make backwards compatible: patch class-level instead of instance. 

## Details
* errors were occurring, e.g.,
  undefined method 'request_response' for class #...
  -- previous code was altering GCR.stub.class (not instance)