### PR TITLE
Improve "multiple stubs" implementation

### DIFF
--- a/lib/gcr.rb
+++ b/lib/gcr.rb
@@ -1,10 +1,12 @@
 require "json"
+require "set"
 
 module GCR
   Error = Class.new(StandardError)
   ConfigError = Class.new(Error)
   RunningError = Class.new(Error)
   NoRecording = Class.new(Error)
+  NoCassette = Class.new(Error)
 
   # Ignore these fields when matching requests.
   #
@@ -37,6 +39,11 @@ module GCR
   # Returns a String path to a directory. Raises ConfigError if not configured.
   def cassette_dir
     @cassette_dir || (raise ConfigError, "no cassette dir configured")
+  end
+
+  def reset_stubs
+    @stub = nil
+    @stubs = nil
   end
 
   # Specify the stub to intercept calls to.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ RSpec.configure do |config|
   config.before(:each) do
     Greetings::Server.start unless Greetings::Server.running?
     GCR.cassette_dir = TMP_DIR
+    GCR.reset_stubs
     GCR.stub = Greetings::Client.stub
     GCR::Cassette.delete_all
   end


### PR DESCRIPTION
# Overview
These are stability and feature-related changes extracted from local development.

## Details
* add GCR.reset_stubs to start from a clean slate
  * since stubs are retained globally
* add a GCR::NoCassette error
  * since request_response may not be executed within the context that
    it was originally defined in (with instance.class_eval)
* fix detection of whether an instance.class is already_intercepted?
  * reintroduce cleanup of .orig_request_response to prevent infinite
    loops
  * problem: it's possible that a stub is overridden (monkey-patched)
    multiple times when using multiple cassettes, since stubs are
    retained globally (if not explicitly cleared)
* fix uninitialized constant GCR::Set